### PR TITLE
Dont log nginx configs

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,15 +13,18 @@
     openresty_includes:
       - content: '{{ openresty_conf }}'
         dest: nginx.conf
+  no_log: true
 
 - set_fact:
     openresty_includes: >-
       {{ openresty_includes + [{ "content": item.value, "dest": "conf.d/" + item.key }]}}
+  no_log: true
   loop: '{{ openresty_includes_extras | dict2items }}'
 
 - set_fact:
     openresty_includes: >-
       {{ openresty_includes + [{ "content": lookup("template", item), "dest": "conf.d/" + item }]}}
+  no_log: true
   loop: '{{ openresty_includes_builtin }}'
 
 - name: Template the config files


### PR DESCRIPTION
The output is usually messy

```
forwarded_for;\n    proxy_set_header Authorization "";\n  }\n\n
location /api/payment {\n    auth_basic off;\n    proxy_pass
http://gunicorn;\n    proxy_set_header Host $host;\n    proxy_set_header
X-Real-IP $remote_addr;\n    proxy_set_header X-Forwarded-For
$proxy_add_x_forwarded_for;\n  }\n\n  location = /agent/ {\n    rewrite
^/agent(.+)$ /porta
```